### PR TITLE
Support to copy from memory fs to real fs

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ WebpackCopyOnBuildPlugin.prototype.apply = function(compiler) {
 				fs = require('fs');
 			}
 
-			console.log();
 
 			var rd = fs.createReadStream(from);
 


### PR DESCRIPTION
Added flag with default false value that allows copying from memory fs to real fs.
It may be helpful when you use webpack-live server and want to copy build.js to the real folder.